### PR TITLE
Feature/backend/add store media for assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ The "Asset Packs" table manages information about various asset packs available 
 - **Store Media List:** A list of dictionaries that describe media content that is used for presentation of the asset pack on the store. Each dictionary has the folowing format:
 
     ```markdown
-    {'file_address':'The url for the media file','type':'tumbnail'} 
+    {'web_address':'The url for the media file','type':'tumbnail'} 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # AssetStore
 Uma loja de assets para atender produtores e desenvolvedores de jogos.
+
+## Backend:
+
+### User Table:
+
+The "User" table manages user information within the system. Each user is uniquely identified by an ID generated based on their username. The table includes the following fields:
+- **ID:** A unique identifier for each user, generated using a hashing function based on the user's name.
+- **Name:** The username of the user.
+- **Password:** The hashed and salted password of the user for secure authentication.
+- **Purchased Asset Packs:** A list of asset packs that the user has purchased. Each item on the list is an id for an asset_pack that is refferenced on the ***Asset pack table***.
+
+    ```markdown
+    ['item id','another item id', ...]
+    
+- **Hash:** The hash of the user's password for verification during login.
+- **Salt:** The salt used during password hashing.
+- **Rounds:** The number of rounds used during password hashing.
+- **Hashed:** The final hashed password stored in the database.
+
+### Asset Packs Table:
+
+The "Asset Packs" table manages information about various asset packs available in the system. Each asset pack is uniquely identified by an ID generated based on its title. The table includes the following fields:
+
+- **ID:** A unique identifier for each asset pack, generated using a hashing function based on the asset pack's title.
+- **Title:** The title or name of the asset pack.
+- **Description:** A brief description of the contents or purpose of the asset pack.
+- **Web Address:** The web address or URL associated with the asset pack.
+- **Store Media List:** A list of dictionaries that describe media content that is used for presentation of the asset pack on the store. Each dictionary has the folowing format:
+
+    ```markdown
+    {'file_address':'The url for the media file','type':'tumbnail'} 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,2 +1,0 @@
-# AssetStore
-Uma loja de assets para atender produtores e desenvolvedores de jogos.

--- a/backend/api/chalicelib/DAO/asset_pack_dao.py
+++ b/backend/api/chalicelib/DAO/asset_pack_dao.py
@@ -19,15 +19,14 @@ class Asset_pack_DAO(base_dao.BaseDAO):
     #Must be implemented by derivative class
     def format_item_for_writing(self,item_id,item_param):
         formated_store_media = []
-        store_media = item_param['store_media'] 
-        if store_media:
-            for media in store_media:
-                formated_media = {'M':{
-                    'web_address':{'S':media['web_address']},
-                    'type':{'S':media['type']}
-                    }}
-                formated_store_media.append(formated_media)
-        
+        store_media = item_param.get('store_media',[]) 
+        for media in store_media:
+            formated_media = {'M':{
+                'web_address':{'S':media['web_address']},
+                'type':{'S':media['type']}
+                }}
+            formated_store_media.append(formated_media)
+    
         item = {
             'id':{'S':item_id},
             'title':{'S':item_param['title']},

--- a/backend/api/chalicelib/DAO/asset_pack_dao.py
+++ b/backend/api/chalicelib/DAO/asset_pack_dao.py
@@ -49,7 +49,7 @@ class Asset_pack_DAO(base_dao.BaseDAO):
             item = read_item_data
         
         if 'store_media' in read_item_data:
-            read_store_media = item['store_media']['L']     
+            read_store_media = item['store_media'].get('L',None)    
             if read_store_media:
                 for media in read_store_media:
                     store_media.append({

--- a/backend/api/chalicelib/DAO/asset_pack_dao.py
+++ b/backend/api/chalicelib/DAO/asset_pack_dao.py
@@ -42,16 +42,28 @@ class Asset_pack_DAO(base_dao.BaseDAO):
     #Format item from reading operations    
     def format_item_from_reading(self,read_item_data):
         
+        store_media = []
+
         if 'Item' in read_item_data:
             item = read_item_data['Item']
         else:
             item = read_item_data
+        
+        if 'store_media' in read_item_data:
+            read_store_media = item['store_media']['L']     
+            if read_store_media:
+                for media in read_store_media:
+                    store_media.append({
+                    'web_address':media['M']['web_address']['S'],
+                    'type':media['M']['type']['S']
+                    }) 
 
         return  {
             'title': item['title']['S'],
             'description': item['description']['S'],
             'web_address': item['web_address']['S'],
-            'id': item['id']['S']
+            'id': item['id']['S'],
+            'store_media':store_media
         }
 
     #[IMPLEMENTATION] 

--- a/backend/api/chalicelib/DAO/asset_pack_dao.py
+++ b/backend/api/chalicelib/DAO/asset_pack_dao.py
@@ -18,11 +18,23 @@ class Asset_pack_DAO(base_dao.BaseDAO):
     # Format item for writing operations 
     #Must be implemented by derivative class
     def format_item_for_writing(self,item_id,item_param):
+        formated_store_media = []
+        store_media = item_param['store_media'] 
+        if store_media:
+            for media in store_media:
+                formated_media = {'M':{
+                    'web_address':{'S':media['web_address']},
+                    'type':{'S':media['type']}
+                    }}
+                formated_store_media.append(formated_media)
+        
         item = {
             'id':{'S':item_id},
             'title':{'S':item_param['title']},
             'description':{'S':item_param['description']},
-            'web_address':{'S':item_param['web_address']}
+            'web_address':{'S':item_param['web_address']},
+            'store_media':{'L':formated_store_media},
+
         }
         return item
 

--- a/backend/api/chalicelib/DAO/asset_pack_dao.py
+++ b/backend/api/chalicelib/DAO/asset_pack_dao.py
@@ -70,13 +70,22 @@ class Asset_pack_DAO(base_dao.BaseDAO):
     #Create update expressions
     #Must return update expressions for update operations 
     def create_update_expression(self,item_param):
+        formated_store_media = []        
+        store_media = item_param.get('store_media',[])
+        for media in store_media:
+            formated_store_media.append({"M":{
+                'web_address':{"S":media['web_address']},
+                'type':{"S":media['type']}
+            }}) 
+
         expression = update_expression.UpdateExpression(
-            "SET #t = :new_title, #d = :new_description,#w = :new_web_address",
-            {"#t": "title", "#d": "description", "#w":"web_address"},
+            "SET #t = :new_title, #d = :new_description,#w = :new_web_address,#stm = :new_store_media",
+            {"#t": "title", "#d": "description", "#w":"web_address","#stm":"store_media"},
             {
                 ":new_title": {"S": item_param['title']},
                 ":new_description": {"S": item_param['description']},
                 ":new_web_address": {"S": item_param['web_address']},
+                ":new_store_media":{"L":formated_store_media}
             }
         )
         return expression

--- a/backend/api/chalicelib/DAO/base_dao.py
+++ b/backend/api/chalicelib/DAO/base_dao.py
@@ -18,7 +18,7 @@ class BaseDAO:
     #Create id for a item
     #Must be implemented by derivative class
     def create_item_id(self,item_param):
-        #Example: 
+        #Example implementation: 
         #return data_util.create_hash(item_param['name']) 
         return None
 

--- a/backend/api/chalicelib/DAO/user_dao.py
+++ b/backend/api/chalicelib/DAO/user_dao.py
@@ -70,20 +70,6 @@ class User_DAO(base_dao.BaseDAO):
         }
 
 
-#Atualizado para compensar a já retirada do Item no input do método
-
-#       if 'Item' in read_item_data:
-#            item = read_item_data['Item']
-#            if not item['purchased_asset_packs']:
-#                item['purchased_asset_packs']['SS'] = {'SS':['']}
-#            return  {
-#                        'name':item['name']['S'],
-#                        'password': item['password']['S'],
-#                        'purchased_asset_packs':item['purchased_asset_packs']['SS']
-#                    }
-#        return None
-
-
     #[IMPLEMENTATION] 
     #Create update expressions
     #Must return update expressions for update operations 

--- a/backend/api/tests/test_asset_pack_dao.py
+++ b/backend/api/tests/test_asset_pack_dao.py
@@ -12,6 +12,8 @@ class TestAsset_pack_DAO:
     _asset_pack_table_name = table_names['asset_packet_table']
     _dao = None
 
+    _skip_teardown = True
+
     @classmethod
     def _delete_table(cls):
         print('Entering _delete_table\n')
@@ -67,9 +69,15 @@ class TestAsset_pack_DAO:
     #asset_pack_DAO must create item on asset_pack table
     def test_create_asset_pack(self):
         print('\n[[Entering test_create_asset_pack]]\n')
+        store_media_param = [
+                                {'web_address': 'http://www.archive.com/24376/thumb1.png','type':'thumbnail'},
+                                {'web_address': 'http://www.archive.com/24376/thumb2.png','type':'thumbnail'}
+                            ]
         asset_pack_param = {'title': 'Medieval Tileset',
                       'description': 'A packet containing medieval themed tilesets for 2D RPG Games',
-                      'web_address': 'http://www.archive.com/63482/medievaltiles.zip'}
+                      'web_address': 'http://www.archive.com/63482/medievaltiles.zip',
+                      'store_media': store_media_param }
+        
         id = self._dao.create_item(asset_pack_param)
         print('expected item id as response. Received ' + id)
         time.sleep(self._SLEEP)
@@ -78,7 +86,9 @@ class TestAsset_pack_DAO:
         assert response["title"] == asset_pack_param["title"],f'Error testing created asset_pack. name diverges'
         assert response["description"] == asset_pack_param["description"],f'Error testing created asset_pack. description diverges'
         assert response["web_address"] == asset_pack_param["web_address"],f'Error testing created asset_pack. url diverges'
-    
+        assert response["store_media"] == asset_pack_param["store_media"],f'Error testing created asset_pack. store media diverges'
+        
+    """
     #asset_pack_DAO must read an existing asset_pack
     def test_read_asset_pack(self):
         print('\n[[Entering test_read_asset_pack]]\n')
@@ -187,9 +197,12 @@ class TestAsset_pack_DAO:
 
         else:
             printf("Test skipped (asset_pack table not found)\n")
-
+    """
 
     def teardown_class(self):
         print('\n[[Entering teardown_class]]\n')
+        if self._skip_teardown:
+            print('\n Teardown skipped \n')
+            return
         self._delete_table()
 

--- a/backend/api/tests/test_asset_pack_dao.py
+++ b/backend/api/tests/test_asset_pack_dao.py
@@ -12,7 +12,7 @@ class TestAsset_pack_DAO:
     _asset_pack_table_name = table_names['asset_packet_table']
     _dao = None
 
-    _skip_teardown = True
+    _skip_teardown = False
 
     @classmethod
     def _delete_table(cls):
@@ -41,13 +41,14 @@ class TestAsset_pack_DAO:
         return item
 
     @classmethod
-    def _create_table_item(cls,name,description,url):
+    def _create_table_item(cls,name,description,url,store_media):
         table = cls._get_table()
         if table:
             asset_pack_param = {
                             'title': name,
                             'description': description,
-                            'web_address': url
+                            'web_address': url,
+                            'store_media':store_media
                         }
             
             asset_pack_id = cls._dao.create_item(asset_pack_param)
@@ -88,20 +89,28 @@ class TestAsset_pack_DAO:
         assert response["web_address"] == asset_pack_param["web_address"],f'Error testing created asset_pack. url diverges'
         assert response["store_media"] == asset_pack_param["store_media"],f'Error testing created asset_pack. store media diverges'
         
-    """
+
     #asset_pack_DAO must read an existing asset_pack
     def test_read_asset_pack(self):
         print('\n[[Entering test_read_asset_pack]]\n')
         table = self._get_table()
         if table:
+            store_media_param = [
+                                {'web_address': 'http://www.archive.com/24376/thumb1.png','type':'thumbnail'},
+                                {'web_address': 'http://www.archive.com/24376/thumb2.png','type':'thumbnail'}
+                            ]
+        
             asset_pack_param = {
                 'title':'Spaceship sprites',
                 'description':'2D top down spaceship sprites',
-                'web_address':'http://www.archive.com/68758sfs850/2dSpaceships.zip'
+                'web_address':'http://www.archive.com/68758sfs850/2dSpaceships.zip',
+                'store_media': store_media_param
             }
             asset_pack_id = self._create_table_item(asset_pack_param['title'],
                                 asset_pack_param['description'],
-                                asset_pack_param['web_address'])
+                                asset_pack_param['web_address'],
+                                asset_pack_param['store_media'])
+                                
             assert asset_pack_id != return_values.TABLE_NOT_FOUND,f'Error creating item before deletion'
             
             response = self._dao.read_item(asset_pack_id)
@@ -110,11 +119,12 @@ class TestAsset_pack_DAO:
                 'id':asset_pack_id,
                 'title':asset_pack_param['title'],
                 'description':asset_pack_param['description'],
-                'web_address':asset_pack_param['web_address']
+                'web_address':asset_pack_param['web_address'],
+                'store_media':store_media_param
             },f'Error reading asset_pack. Incorrect response'
         else:
             print("Test skipped (asset_pack Table not found)\n")    
-
+    """
     #asset_pack_DAO must update an existing asset_pack
     def test_update_asset_pack(self):
         print('\n[[Entering test_update_asset_pack]]\n')

--- a/backend/api/tests/test_asset_pack_dao.py
+++ b/backend/api/tests/test_asset_pack_dao.py
@@ -110,7 +110,7 @@ class TestAsset_pack_DAO:
                                 asset_pack_param['description'],
                                 asset_pack_param['web_address'],
                                 asset_pack_param['store_media'])
-                                
+
             assert asset_pack_id != return_values.TABLE_NOT_FOUND,f'Error creating item before deletion'
             
             response = self._dao.read_item(asset_pack_id)
@@ -124,30 +124,47 @@ class TestAsset_pack_DAO:
             },f'Error reading asset_pack. Incorrect response'
         else:
             print("Test skipped (asset_pack Table not found)\n")    
-    """
+    
     #asset_pack_DAO must update an existing asset_pack
     def test_update_asset_pack(self):
         print('\n[[Entering test_update_asset_pack]]\n')
         table = self._get_table()
         if table:
+            
+            store_media_param = [
+                                {'web_address': 'http://www.archive.com/24376/thumb1.png','type':'thumbnail'},
+                                {'web_address': 'http://www.archive.com/24376/thumb2.png','type':'thumbnail'}
+                            ]
+        
             asset_pack_id = self._create_table_item('Spaceship sprites',
                                 '2D top down spaceship sprites',
-                                'http://www.archive.com/68758sfs850/2dSpaceships.zip')
+                                'http://www.archive.com/68758sfs850/2dSpaceships.zip',
+                                 store_media_param)
+                    
             assert asset_pack_id != return_values.TABLE_NOT_FOUND,f'Error creating item before deletion'
+            
+            updated_store_media_param = [
+                                {'web_address': 'http://www.archive.com/update24376/updated_thumb1.png','type':'thumbnail'},
+                                {'web_address': 'http://www.archive.com/update24376/updated_thumb2.png','type':'thumbnail'}
+                            ]
+
             updated_item_param = {
                 'title':'2D city textures',
                 'description':'Set of realistic textures for urban locations',
-                'web_address':'http://www.archive.com/68758850/urban_textures.zip'
+                'web_address':'http://www.archive.com/68758850/urban_textures.zip',
+                'store_media': updated_store_media_param
             }
             
             result = self._dao.update_item(asset_pack_id,updated_item_param)
+            print(result)
             assert result == return_values.SUCCESS,f'Error testing asset_pack update. Incorrect response'
             
             response = self._get_table_item(asset_pack_id)
             assert response['title'] == updated_item_param['title'], f'asset_pack name not properly updated '
             assert response['description'] == updated_item_param['description'], f'asset_pack description not properly updated'
             assert response['web_address'] == updated_item_param['web_address'], f'asset_pack url not properly updated'
-            
+            assert response['store_media'] == updated_item_param['store_media'], f'asset_pack store_media not properly updated'
+
         else:
             print("Test skipped (asset_pack Table not found)\n")
 
@@ -207,7 +224,6 @@ class TestAsset_pack_DAO:
 
         else:
             printf("Test skipped (asset_pack table not found)\n")
-    """
 
     def teardown_class(self):
         print('\n[[Entering teardown_class]]\n')

--- a/backend/api/tests/test_asset_pack_dao.py
+++ b/backend/api/tests/test_asset_pack_dao.py
@@ -81,14 +81,35 @@ class TestAsset_pack_DAO:
         
         id = self._dao.create_item(asset_pack_param)
         print('expected item id as response. Received ' + id)
-        time.sleep(self._SLEEP)
+        
         response = self._get_table_item(id)
         print(response)
+        
         assert response["title"] == asset_pack_param["title"],f'Error testing created asset_pack. name diverges'
         assert response["description"] == asset_pack_param["description"],f'Error testing created asset_pack. description diverges'
         assert response["web_address"] == asset_pack_param["web_address"],f'Error testing created asset_pack. url diverges'
         assert response["store_media"] == asset_pack_param["store_media"],f'Error testing created asset_pack. store media diverges'
+
+    #It must be possible to omit store media durint asset pack creation
+    def test_create_asset_pack_without_store_media(self):
+        print('\n[[Entering test_create_asset_pack_without_store_media]]\n')
+        asset_pack_param = {'title': 'Epic music',
+                      'description': 'A packet 7 mp3 tracks of symphonic epic themes',
+                      'web_address': 'http://www.archive.com/6348dfsj2/Ephic_suit_music.zip'
+                        }
         
+        id = self._dao.create_item(asset_pack_param)
+        print('expected item id as response. Received ' + id)
+
+        response = self._get_table_item(id)
+        print(response)
+        
+        assert response["title"] == asset_pack_param["title"],f'Error testing created asset_pack. name diverges'
+        assert response["description"] == asset_pack_param["description"],f'Error testing created asset_pack. description diverges'
+        assert response["web_address"] == asset_pack_param["web_address"],f'Error testing created asset_pack. url diverges'
+        assert response["store_media"] == [],f'Error testing created asset_pack. store media diverges'
+
+
 
     #asset_pack_DAO must read an existing asset_pack
     def test_read_asset_pack(self):

--- a/backend/api/tests/test_asset_pack_dao.py
+++ b/backend/api/tests/test_asset_pack_dao.py
@@ -41,7 +41,7 @@ class TestAsset_pack_DAO:
         return item
 
     @classmethod
-    def _create_table_item(cls,name,description,url,store_media):
+    def _create_table_item(cls,name,description,url,store_media = []):
         table = cls._get_table()
         if table:
             asset_pack_param = {
@@ -156,7 +156,7 @@ class TestAsset_pack_DAO:
             }
             
             result = self._dao.update_item(asset_pack_id,updated_item_param)
-            print(result)
+
             assert result == return_values.SUCCESS,f'Error testing asset_pack update. Incorrect response'
             
             response = self._get_table_item(asset_pack_id)
@@ -175,7 +175,8 @@ class TestAsset_pack_DAO:
         if table:
             asset_pack_id = self._create_table_item('Spaceship sprites',
                                 '2D top down spaceship sprites',
-                                'http://www.archive.com/68758sfs850/2dSpaceships.zip')
+                                'http://www.archive.com/68758sfs850/2dSpaceships.zip',
+                                )
             assert asset_pack_id != return_values.TABLE_NOT_FOUND,f'Error: item not created (TABLE NOT FOUND)'
             result = self._dao.delete_item(asset_pack_id)
             assert result == return_values.SUCCESS,f'Error testing delete asset_pack. Incorrect response'

--- a/backend/api/tests/test_user_dao.py
+++ b/backend/api/tests/test_user_dao.py
@@ -81,7 +81,28 @@ class TestUserDAO:
         print(response)
         assert response["name"] == user_param["name"],f'Error testing created user. name diverges'
         assert response["password"] == user_param["password"],f'Error testing created user. password diverges'
+        assert response['purchased_asset_packs'] == user_param['purchased_asset_packs'],f'Error testing created user. purchased_asset_packs diverges'
     
+    # It must be possible to omit purchased assets suring user creation. 
+    def test_create_user_without_purchased(self):
+        print('\n[[Entering test_create_user_without_purchased]]\n')
+        
+        user_param = {
+                'name':'Baby da Silva Sauro',
+                'password':'naoeamamae'
+            }
+
+        user_id = self._dao.create_item(user_param)
+        assert user_id != return_values.TABLE_NOT_FOUND,f'Error creating user (table not found)'
+        
+        response = self._get_table_item(user_id)
+        print(response)
+        
+        assert response["name"] == user_param["name"],f'Error testing created user. name diverges'
+        assert response["password"] == user_param["password"],f'Error testing created user. password diverges'
+        assert response["purchased_asset_packs"] == [''],f'Error testing created user. purchased_asset_packs diverges'
+    
+
     #User_DAO must read an existing user
     def test_read_user(self):
         print('\n[[Entering test_read_user]]\n')


### PR DESCRIPTION
Add store media information to asset_packs registering. 
Store media consists of a list of dictionaries that describe media content that is used for presentation of the asset pack on the store. Each dictionary has the folowing format:

    {'web_address':'The url for the media file','type':'tumbnail'} 

Currently only the tumbnail type is supported. 